### PR TITLE
allow macOS delta upgrades

### DIFF
--- a/Assets/nudge.json
+++ b/Assets/nudge.json
@@ -1,48 +1,23 @@
 {
   "optionalFeatures": {
-    "aggressiveUserExperience": true,
-    "aggressiveUserFullScreenExperience": true,
-    "asynchronousSoftwareUpdate": true,
-    "attemptToFetchMajorUpgrade": true,
-    "enforceMinorUpdates": true
+    "attemptToFetchMajorUpgrade": false,
+    "disableSoftwareUpdateWorkflow": true
   },
   "osVersionRequirements": [
     {
       "aboutUpdateURL": "https://support.apple.com/en-us/HT201541",
-      "majorUpgradeAppPath": "/Applications/Install macOS Sonoma.app",
-      "requiredInstallationDate": "2023-12-02T00:00:00Z",
-      "requiredMinimumOSVersion": "14.1.2",
-      "targetedOSVersionsRule": "14.1.1"
-    },
-    {
-      "aboutUpdateURL": "https://support.apple.com/en-us/HT201541",
-      "majorUpgradeAppPath": "/Applications/Install macOS Sonoma.app",
+      "majorUpgradeAppPath": "/System/Library/CoreServices/Software Update.app",
       "requiredInstallationDate": "2023-12-02T00:00:00Z",
       "requiredMinimumOSVersion": "14.1.2",
       "targetedOSVersionsRule": "default"
     }
   ],
   "userExperience": {
-    "allowUserQuitDeferrals": true,
-    "allowedDeferrals": 1000000,
-    "allowedDeferralsUntilForcedSecondaryQuitButton": 14,
-    "approachingRefreshCycle": 6000,
-    "approachingWindowTime": 72,
-    "elapsedRefreshCycle": 300,
-    "imminentRefreshCycle": 600,
-    "imminentWindowTime": 24,
-    "initialRefreshCycle": 18000,
-    "maxRandomDelayInSeconds": 1200,
-    "noTimers": false,
-    "nudgeRefreshCycle": 60,
-    "randomDelay": false
+    "maxRandomDelayInSeconds": 300,
+    "randomDelay": true
   },
   "userInterface": {
-    "fallbackLanguage": "en",
-    "forceFallbackLanguage": false,
-    "showDeferralCount": true,
-    "simpleMode": false,
-    "singleQuitButton": false,
+    "actionButtonPath": "/System/Library/CoreServices/Software Update.app",
     "updateElements": [
       {
         "_language": "en",


### PR DESCRIPTION
Use built-in software update pane as `majorUpgradeAppPath` and `actionButtonPath`
- [per new documented Nudge best practices](https://github.com/macadmins/nudge/issues/417), because macOS upgrades no longer download as standalone apps

Stop attempting to download macOS upgrade app or minor updates via Apple's buggy `softwareupdate` binary

Also remove non-custom values, and use defaults instead